### PR TITLE
Fix link errors on macOS

### DIFF
--- a/src/libhandler.c
+++ b/src/libhandler.c
@@ -93,8 +93,17 @@
 #if defined(HAS_ASMSETJMP)
 // define the lh_jmp_buf in terms of `void*` elements to have natural alignment
 typedef void* lh_jmp_buf[ASM_JMPBUF_SIZE/sizeof(void*)];
+
+// Workaround macOS ABI prepending an underscore to external C functions
+#if defined(__MACH__)
+__externc __returnstwice int  lh_setjmp(lh_jmp_buf buf);
+__externc __noreturn     void lh_longjmp(lh_jmp_buf buf, int arg);
+# define _lh_setjmp lh_setjmp
+# define _lh_longjmp lh_longjmp
+#else
 __externc __returnstwice int  _lh_setjmp(lh_jmp_buf buf);
 __externc __noreturn     void _lh_longjmp(lh_jmp_buf buf, int arg);
+#endif
 
 #elif defined(HAS__SETJMP)
 # define lh_jmp_buf   jmp_buf


### PR DESCRIPTION
macOS prepends an underscore to the name of external C functions [when looking up symbols](https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/MachOTopics/1-Articles/executing_files.html#//apple_ref/doc/uid/TP40001829-97182-TPXREF112) at link time, causing link errors for `_lh_longjmp` and `_lh_setjmp` when running `make tests`.

This PR works around this in a somewhat hacky way; but given the discrepancy in behavior from pretty much every other platform, it seems inevitable that the fix will be equally ugly.

After this change, the link errors are resolved. Additionally, all tests pass on macOS now.

Fixes #1.